### PR TITLE
Some work

### DIFF
--- a/crates/eelco/src/app/state.rs
+++ b/crates/eelco/src/app/state.rs
@@ -140,7 +140,7 @@ impl State {
                 if sanitized != expected_result.as_str() {
                     anyhow::bail!(indoc::formatdoc! {"
                         {id}
-                        actual (sanitized): {sanitized:?}
+                        actual (sanitized): {sanitized}
                         expected          : {expected_result}"
                     })
                 }

--- a/crates/eelco/src/app/state.rs
+++ b/crates/eelco/src/app/state.rs
@@ -131,15 +131,11 @@ impl State {
             } => 'arm: {
                 acc.push(ch.into());
 
-                let Some(stripped_crlf_once) = acc.strip_suffix("\r\n") else {
+                let Some(stripped_crlf_twice) = acc.strip_suffix("\r\n\r\n") else {
                     break 'arm vec![];
                 };
 
-                if !stripped_crlf_once.ends_with("\r\n") {
-                    break 'arm vec![];
-                }
-
-                let sanitized = Self::sanitize(stripped_crlf_once)?;
+                let sanitized = Self::sanitize(stripped_crlf_twice)?;
 
                 if sanitized != expected_result.as_str() {
                     anyhow::bail!(indoc::formatdoc! {"

--- a/crates/eelco/src/repl/example.rs
+++ b/crates/eelco/src/repl/example.rs
@@ -56,7 +56,9 @@ impl TryFrom<(LFLine, LFLine)> for ReplEntry {
     fn try_from((query, response): (LFLine, LFLine)) -> Result<Self, Self::Error> {
         Ok(Self {
             query: query.try_into()?,
-            expected_result: ExpectedResult(response.as_str().to_owned()),
+            expected_result: ExpectedResult(
+                response.as_str().strip_suffix('\n').unwrap().to_owned(),
+            ),
         })
     }
 }

--- a/crates/eelco/tests/misc.rs
+++ b/crates/eelco/tests/misc.rs
@@ -1,0 +1,11 @@
+use util::with_eelco;
+
+#[test]
+fn empty_file() {
+    with_eelco(|_file, eelco| {
+        eelco
+            .assert()
+            .failure()
+            .stderr("Error: could not find any REPL examples\n");
+    });
+}

--- a/crates/eelco/tests/repl.rs
+++ b/crates/eelco/tests/repl.rs
@@ -36,9 +36,8 @@ fn result_mismatch() {
 
         eelco.assert().failure().stderr(formatdoc! {r#"
             Error: {file_path}:1
-            actual (sanitized): "2\n"
+            actual (sanitized): "2"
             expected          : 3
-
          "#});
     });
 }

--- a/crates/eelco/tests/repl.rs
+++ b/crates/eelco/tests/repl.rs
@@ -3,17 +3,7 @@ use indoc::indoc;
 use util::with_eelco;
 
 #[test]
-fn empty_file() {
-    with_eelco(|_file, eelco| {
-        eelco
-            .assert()
-            .failure()
-            .stderr("Error: could not find any REPL examples\n");
-    });
-}
-
-#[test]
-fn example_fails_to_parse() {
+fn fails_to_parse() {
     with_eelco(|file, eelco| {
         file.write_str(indoc! {"
             ```nix-repl

--- a/crates/eelco/tests/repl.rs
+++ b/crates/eelco/tests/repl.rs
@@ -6,11 +6,11 @@ use util::with_eelco;
 fn fails_to_parse() {
     with_eelco(|file, eelco| {
         file.write_str(indoc! {"
-            ```nix-repl
-            nix-shnepl> nope
-            dope
-            ```
-        "})
+                ```nix-repl
+                nix-shnepl> nope
+                dope
+                ```
+            "})
             .unwrap();
 
         eelco
@@ -24,12 +24,12 @@ fn fails_to_parse() {
 fn pass() {
     with_eelco(|file, eelco| {
         file.write_str(indoc! {"
-            ```nix-repl
-            nix-repl> 1 + 1
+                ```nix-repl
+                nix-repl> 1 + 1
 
-            2
-            ```
-        "})
+                2
+                ```
+            "})
             .unwrap();
 
         let file_path = file.path().to_str().unwrap();

--- a/crates/eelco/tests/repl.rs
+++ b/crates/eelco/tests/repl.rs
@@ -36,7 +36,7 @@ fn result_mismatch() {
 
         eelco.assert().failure().stderr(formatdoc! {r#"
             Error: {file_path}:1
-            actual (sanitized): "2"
+            actual (sanitized): 2
             expected          : 3
         "#});
     });

--- a/crates/eelco/tests/repl.rs
+++ b/crates/eelco/tests/repl.rs
@@ -38,7 +38,7 @@ fn result_mismatch() {
             Error: {file_path}:1
             actual (sanitized): "2"
             expected          : 3
-         "#});
+        "#});
     });
 }
 


### PR DESCRIPTION
- test: split into two files
- style: format some macro invocations in test
- test: result_mismatch
- feat: rm extraneous LF from result mismatch output
- style: fix indent in some test
- feat: no debug fmt in result mismatch output
